### PR TITLE
show compile output

### DIFF
--- a/dev/start.js
+++ b/dev/start.js
@@ -44,6 +44,16 @@ function web() {
       Logger.info('Started compiling');
     });
 
+    compiler.plugin('failed', err => {
+      Logger.failed(err);
+    });
+
+    compiler.plugin('compilation', compilation => {
+      compilation.plugin('failed-module', err => {
+        Logger.failed(err.error.error);
+      });
+    });
+
     const openBrowser = _.once(() => open());
 
     _.onceEvery = function(times, func) {
@@ -64,7 +74,7 @@ function web() {
     //
     // https://blogs.msdn.microsoft.com/ieinternals/2011/05/14/stylesheet-limits-in-internet-explorer
     //
-    const message = _.onceEvery(2, stats => {
+    const message = stats => {
 
       openBrowser();
 
@@ -83,7 +93,7 @@ function web() {
       Logger.ok('Finished compiling');
       Logger.box(`The app is running at ${chalk.green(uri)}`);
 
-    });
+    };
 
     compiler.plugin('done', stats => {
 


### PR DESCRIPTION
So here the deal, without bless the output never shows since it is waiting for done to be hit twice. Wihtout this output, the last thing you'll see is `Webpack optimize chunk assets` and it is hard to tell what is going on...

This make the output show, but with bless it will show twice....(since bless will hit it a second time)

I also added some stuff to display errors if there are some.

The todo here is to determine if bless in being used and show the compile output accordingly.
